### PR TITLE
priority down

### DIFF
--- a/src/kkc.conf.in
+++ b/src/kkc.conf.in
@@ -2,6 +2,6 @@
 UniqueName=kkc
 _Name=Kana Kanji
 IconName=kkc
-Priority=1
+Priority=3
 LangCode=ja
 Parent=fcitx-kkc


### PR DESCRIPTION
libkkc is a good conversion engine, but not the best.
Mozc is the best conversion engine at least for a while.
So fcitx-kkc's priority should be lower than fcitx-mozc.
